### PR TITLE
ridgepole の導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,3 +45,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'ridgepole'

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'annotate'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    annotate (3.0.3)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
@@ -202,6 +205,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   bootsnap (>= 1.4.2)
   byebug
   database_cleaner

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     crass (1.0.6)
     database_cleaner (1.8.2)
     diff-lcs (1.3)
+    diffy (3.3.0)
     erubi (1.9.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
@@ -136,6 +137,9 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    ridgepole (0.8.6)
+      activerecord (>= 5.0.1, < 6.1)
+      diffy
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)
@@ -207,6 +211,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.1)
+  ridgepole
   rspec-rails
   sass-rails (>= 6)
   spring

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,11 @@ module RetrospectiveBoard
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # NOTE: Ridgepole の Schemafile に書くのでマイグレーションファイルは作らない
+    config.generators do |g|
+      g.active_record migration: false
+      g.test_framework :rspec, controller_specs: false
+    end
   end
 end

--- a/db/Schemafile
+++ b/db/Schemafile
@@ -1,0 +1,3 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,37 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'position_in_routes' => 'before',
+      'position_in_class' => 'before',
+      'position_in_test' => 'before',
+      'position_in_fixture' => 'before',
+      'position_in_factory' => 'before',
+      'position_in_serializer' => 'before',
+      'show_foreign_keys' => 'true',
+      'show_indexes' => 'true',
+      'simple_indexes' => 'false',
+      'model_dir' => 'app/models',
+      'include_version' => 'false',
+      'require' => '',
+      'exclude_tests' => 'false',
+      'exclude_fixtures' => 'false',
+      'exclude_factories' => 'false',
+      'exclude_serializers' => 'false',
+      'ignore_model_sub_dir' => 'false',
+      'skip_on_db_migrate' => 'false',
+      'format_bare' => 'false',
+      'format_rdoc' => 'false',
+      'format_markdown' => 'true',
+      'sort' => 'false',
+      'force' => 'false',
+      'trace' => 'false',
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/lib/tasks/ridgepole.rake
+++ b/lib/tasks/ridgepole.rake
@@ -33,6 +33,7 @@ task 'db:migrate' do
 
   if Rails.env.development?
     Rake::Task['ridgepole:export'].invoke
+    Annotate::Migration.update_annotations
   end
 end
 

--- a/lib/tasks/ridgepole.rake
+++ b/lib/tasks/ridgepole.rake
@@ -1,0 +1,54 @@
+namespace :ridgepole do
+  desc 'Create a Schemafile file that is portable against any DB supported by Ridgepole'
+  task :export, :rails_env do |_, args|
+    rails_env = args[:rails_env] || ENV['RAILS_ENV'] || 'development'
+    redirect = rails_env == 'test' ? '> /dev/null' : ''
+    sh [
+      'ridgepole --export -o db/Schemafile',
+      "-E #{rails_env}",
+      '-c config/database.yml',
+      redirect
+    ].join(' ')
+  end
+
+  desc 'Apply a Schemafile file into the database'
+  task :apply, :rails_env do |_, args|
+    rails_env = args[:rails_env] || ENV['RAILS_ENV'] || 'development'
+    # NOTE: rspec 実行時に出力結果が表示されて邪魔くさいので消してみる
+    redirect = rails_env == 'test' ? '> /dev/null' : ''
+    sh [
+      'ridgepole --apply -f db/Schemafile',
+      "-E #{rails_env}",
+      '-c config/database.yml',
+      '--create-table-with-index',
+      redirect
+    ].join(' ')
+  end
+end
+
+Rake.application.lookup('db:migrate').clear
+desc 'Migrate the database by Ridgepole'
+task 'db:migrate' do
+  Rake::Task['ridgepole:apply'].invoke
+
+  if Rails.env.development?
+    Rake::Task['ridgepole:export'].invoke
+  end
+end
+
+Rake.application.lookup('db:schema:dump').clear
+desc 'Create a Schemafile file that is portable against any DB supported by Ridgepole'
+task 'db:schema:dump' => 'ridgepole:export'
+
+Rake.application.lookup('db:schema:load').clear
+desc 'Apply a Schemafile file into the database'
+task 'db:schema:load' => 'ridgepole:apply'
+
+Rake.application.lookup('db:test:load').clear
+task 'db:test:load' => %w(db:test:purge) do
+  Rake::Task['ridgepole:apply'].invoke('test')
+end
+
+%w(db:migrate:status db:rollback db:version).each do |name|
+  Rake.application.lookup(name).clear
+end


### PR DESCRIPTION
DB のマイグレーションを楽にするために、 ridgepole を導入する。
その関係で、 model の作成をする際に、 migration ファイルを作成しないようにした。
